### PR TITLE
Add undo/redo history, popover & tooltip fixes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full font-manrope-local" suppressHydrationWarning>
-      <body className="h-full font-sans antialiased bg-background text-foreground">
+      <body className="h-full font-sans antialiased bg-background text-foreground" suppressHydrationWarning>
         <QueryProvider>
           <TooltipProvider>
             <Toaster />

--- a/src/components/canvas/GroupBlock.tsx
+++ b/src/components/canvas/GroupBlock.tsx
@@ -13,6 +13,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 interface Props {
   group: GroupNode;
@@ -67,7 +68,7 @@ function getGroupColors(color: unknown) {
 }
 
 export const GroupBlock: React.FC<Props> = ({ group }) => {
-  const { moveGroup, updateGroupName, removeGroup, removeGroupAndTables, updateGroupColor, addTableToGroup } = useSchemaStore();
+  const { moveGroup, updateGroupName, removeGroup, removeGroupAndTables, updateGroupColor, addTableToGroup, saveHistory } = useSchemaStore();
   
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
@@ -88,6 +89,7 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
     if ((e.target as HTMLElement).closest('.group-name')) return;
     
     e.stopPropagation();
+    saveHistory();
     setIsDragging(true);
     dragStart.current = {
       x: e.clientX,
@@ -122,6 +124,7 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
   // Resizing logic
   const handleResizePointerDown = useCallback((e: React.PointerEvent, dir: string) => {
     e.stopPropagation();
+    saveHistory();
     setIsResizing(true);
     setResizeDir(dir);
     resizeStart.current = {
@@ -172,23 +175,6 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
     (e.target as HTMLElement).releasePointerCapture(e.pointerId);
   }, []);
 
-  useEffect(() => {
-    if (!showMenu) return;
-    const handleOutsideClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setShowMenu(false);
-      }
-    };
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setShowMenu(false);
-    };
-    document.addEventListener('mousedown', handleOutsideClick);
-    document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [showMenu]);
 
   return (
     <ContextMenu>
@@ -228,6 +214,7 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
               <input
                 ref={nameInputRef}
                 value={group.name}
+                onFocus={() => saveHistory()}
                 onChange={(e) => updateGroupName(group.id, e.target.value)}
                 onBlur={() => setIsEditingName(false)}
                 onKeyDown={(e) => {
@@ -260,23 +247,30 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
         </div>
         
         {/* Controls */}
-        <div ref={menuRef} className="group-controls relative flex items-center">
-          <button 
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowMenu(!showMenu);
-            }} 
-            className="p-1 rounded opacity-60 hover:opacity-100 hover:bg-black/10 dark:hover:bg-white/10"
-          >
-            <DotsThree size={16} weight="bold" />
-          </button>
-          
-          {showMenu && (
-            <div className="absolute top-8 right-0 bg-popover text-popover-foreground border border-border rounded-md shadow-xl w-44 z-50 overflow-hidden flex flex-col">
+        <div className="group-controls relative flex items-center">
+          <Popover open={showMenu} onOpenChange={setShowMenu}>
+            <PopoverTrigger asChild>
+              <button 
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowMenu(!showMenu);
+                }} 
+                className="p-1 rounded opacity-60 hover:opacity-100 hover:bg-black/10 dark:hover:bg-white/10"
+              >
+                <DotsThree size={16} weight="bold" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent 
+              align="end" 
+              sideOffset={4}
+              onPointerDownOutside={() => setShowMenu(false)}
+              className="p-0 border-border rounded-md shadow-xl w-44 z-[100] overflow-hidden flex flex-col bg-popover text-popover-foreground"
+            >
               <div className="p-2 border-b border-border space-y-2">
                 <div className="text-[10px] font-semibold uppercase text-muted-foreground px-1">Name</div>
                 <input
                   value={group.name}
+                  onFocus={() => saveHistory()}
                   onChange={(e) => updateGroupName(group.id, e.target.value)}
                   className="w-full text-xs px-2 py-1 rounded bg-secondary text-foreground outline-none focus:ring-1 focus:ring-primary"
                   placeholder="Group Name"
@@ -318,8 +312,8 @@ export const GroupBlock: React.FC<Props> = ({ group }) => {
                   <Trash size={14} /> Delete group & tables
                 </button>
               </div>
-            </div>
-          )}
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
 

--- a/src/components/canvas/SchemaCanvas.tsx
+++ b/src/components/canvas/SchemaCanvas.tsx
@@ -21,7 +21,9 @@ import {
   Table,
   FolderPlus,
   Code,
-  Bug
+  Bug,
+  ArrowCounterClockwise,
+  ArrowClockwise
 } from '@phosphor-icons/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -30,6 +32,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 const CanvasZoomControls: React.FC<{
   zoom: number;
@@ -68,9 +71,12 @@ const CanvasZoomControls: React.FC<{
 
 const SchemaCanvas: React.FC = () => {
   const canvasRef = useRef<HTMLDivElement>(null);
-  const { tables, groups, relationships, pan, zoom, showGrid, selectedIds, connectingFrom } = useSchemaStore();
-  const { setPan, setZoom, addTable, addGroup, setSelectedIds, setEditingTableId, setEditingColumnId, setConnectingFrom } = useSchemaStore();
+  const { tables, groups, relationships, pan, zoom, showGrid, selectedIds, connectingFrom, past, future } = useSchemaStore();
+  const { setPan, setZoom, addTable, addGroup, setSelectedIds, setEditingTableId, setEditingColumnId, setConnectingFrom, undo, redo } = useSchemaStore();
   const chatDockPosition = usePreferencesStore((s) => s.chatDockPosition);
+
+  const isMac = typeof window !== 'undefined' ? /Mac|iPod|iPhone|iPad/.test(navigator.platform) : false;
+  const modKey = isMac ? '⌘' : 'Ctrl';
 
   const [isPanning, setIsPanning] = useState(false);
   const [panStart, setPanStart] = useState({ x: 0, y: 0 });
@@ -207,8 +213,25 @@ const SchemaCanvas: React.FC = () => {
       const target = e.target as HTMLElement;
       const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
       const key = e.key.toLowerCase();
+      const isMod = e.ctrlKey || e.metaKey;
 
-      if (e.key === '/' && !e.ctrlKey && !e.metaKey && !isInput) {
+      if (isMod && key === 'z' && !isInput) {
+        e.preventDefault();
+        if (e.shiftKey) {
+          useSchemaStore.getState().redo();
+        } else {
+          useSchemaStore.getState().undo();
+        }
+        return;
+      }
+      
+      if (isMod && key === 'y' && !isInput) {
+        e.preventDefault();
+        useSchemaStore.getState().redo();
+        return;
+      }
+
+      if (e.key === '/' && !isMod && !isInput) {
         e.preventDefault();
         const rect = canvasRef.current?.getBoundingClientRect();
         if (rect) setSlashMenu({ x: rect.width / 2, y: rect.height / 2 });
@@ -221,8 +244,8 @@ const SchemaCanvas: React.FC = () => {
       }
       if ((e.key === 'Delete' || e.key === 'Backspace') && !isInput) {
         const store = useSchemaStore.getState();
-        for (const id of store.selectedIds) {
-          store.removeTable(id);
+        if (store.selectedIds.length > 0) {
+          store.removeTables(store.selectedIds);
         }
       }
       if (key === 'g' && !e.ctrlKey && !e.metaKey && !isInput) {
@@ -422,15 +445,67 @@ const SchemaCanvas: React.FC = () => {
       {sqlPanelOpen && <SQLPanel onClose={() => setSqlPanelOpen(false)} />}
       <BottomChatInput />
 
-      {/* Zoom controls (bottom-left) */}
+      {/* Zoom controls and Undo/Redo (bottom-left) */}
       <motion.div
         initial={{ y: 18, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ delay: 0.05, duration: 0.28, ease: 'easeOut' }}
-        className="absolute bottom-3 left-3 z-10 pointer-events-none"
+        className="absolute bottom-3 left-3 z-10 pointer-events-none flex items-center gap-2"
       >
         <div className="pointer-events-auto">
           <CanvasZoomControls zoom={zoom} setZoom={setZoom} />
+        </div>
+        
+        {/* Undo / Redo */}
+        <div className="pointer-events-auto flex items-center gap-0.5 h-10 px-1.5 rounded-full bg-floating-bg border border-floating-border shadow-sm">
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <motion.button
+                  whileHover={past.length > 0 ? { scale: 1.05 } : {}}
+                  whileTap={past.length > 0 ? { scale: 0.95 } : {}}
+                  className={`p-1.5 rounded-full transition-colors ${past.length > 0 ? 'text-muted-foreground hover:text-foreground hover:bg-secondary' : 'text-muted-foreground/30 cursor-not-allowed'}`}
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    undo();
+                  }}
+                  disabled={past.length === 0}
+                >
+                  <ArrowCounterClockwise size={18} />
+                </motion.button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={8} className="pointer-events-none text-[11px] font-medium px-2.5 py-1 bg-floating-bg border border-floating-border text-foreground shadow-xl z-[100]">
+                <p>Undo ({modKey} + Z)</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          {/* Separator */}
+          <div className="w-[1px] h-4 bg-border mx-0.5" />
+
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <motion.button
+                  whileHover={future.length > 0 ? { scale: 1.05 } : {}}
+                  whileTap={future.length > 0 ? { scale: 0.95 } : {}}
+                  className={`p-1.5 rounded-full transition-colors ${future.length > 0 ? 'text-muted-foreground hover:text-foreground hover:bg-secondary' : 'text-muted-foreground/30 cursor-not-allowed'}`}
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    redo();
+                  }}
+                  disabled={future.length === 0}
+                >
+                  <ArrowClockwise size={18} />
+                </motion.button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={8} className="pointer-events-none text-[11px] font-medium px-2.5 py-1 bg-floating-bg border border-floating-border text-foreground shadow-xl z-[100]">
+                <p>Redo ({modKey} + {isMac ? 'Shift + Z' : 'Y'})</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </motion.div>
 

--- a/src/components/canvas/SlashCommandMenu.tsx
+++ b/src/components/canvas/SlashCommandMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from 'react';
-import { Table, Code, Robot, Folder, Sun, Moon, CheckCircle, TextAa, GridFour, ShareNetwork, MagnifyingGlassPlus, MagnifyingGlassMinus, Bug, CornersOut, Trash, Minus } from '@phosphor-icons/react';
+import { Table, Code, Robot, Folder, Sun, Moon, CheckCircle, TextAa, GridFour, ShareNetwork, MagnifyingGlassPlus, MagnifyingGlassMinus, Bug, CornersOut, Trash, Minus, ArrowCounterClockwise, ArrowClockwise } from '@phosphor-icons/react';
 import { usePreferencesStore } from '@/store/preferencesStore';
 import { useSchemaStore } from '@/store/schemaStore';
 
@@ -14,7 +14,7 @@ interface Props {
 
 export const SlashCommandMenu: React.FC<Props> = ({ position, onSelect, onAskAI, onClose }) => {
   const { theme, setTheme, fontPreference, setFontPreference } = usePreferencesStore();
-  const { showGrid, toggleGrid, zoom, setZoom } = useSchemaStore();
+  const { showGrid, toggleGrid, zoom, setZoom, undo, redo } = useSchemaStore();
   const [filter, setFilter] = useState('');
   const [activeIdx, setActiveIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -24,6 +24,8 @@ export const SlashCommandMenu: React.FC<Props> = ({ position, onSelect, onAskAI,
     { id: 'table', label: 'Add Table', icon: Table },
     { id: 'group', label: 'Create Group', icon: Folder },
     { id: 'sql', label: 'View SQL', icon: Code },
+    { id: 'undo', label: 'Undo', icon: ArrowCounterClockwise },
+    { id: 'redo', label: 'Redo', icon: ArrowClockwise },
     { id: 'chat-expand', label: 'Expand Chat', icon: CornersOut },
     { id: 'chat-minimize', label: 'Minimize Chat', icon: Minus },
     { id: 'chat-clear', label: 'Clear Chat', icon: Trash },
@@ -89,6 +91,8 @@ export const SlashCommandMenu: React.FC<Props> = ({ position, onSelect, onAskAI,
     if (id === 'grid') { toggleGrid(); onClose(); return; }
     if (id === 'zoom-in') { setZoom(zoom + 0.1); onClose(); return; }
     if (id === 'zoom-out') { setZoom(zoom - 0.1); onClose(); return; }
+    if (id === 'undo') { undo(); onClose(); return; }
+    if (id === 'redo') { redo(); onClose(); return; }
     if (id === 'issue') { window.open('https://github.com/dev-hari-prasad/schema-pad/issues/new', '_blank'); onClose(); return; }
     if (id === 'chat-expand') { window.dispatchEvent(new CustomEvent('schema:open-ai-chat')); onClose(); return; }
     if (id === 'chat-minimize') { window.dispatchEvent(new CustomEvent('schema:minimize-ai-chat')); onClose(); return; }

--- a/src/components/canvas/TableBlock.tsx
+++ b/src/components/canvas/TableBlock.tsx
@@ -31,7 +31,7 @@ export const TableBlock: React.FC<TableBlockProps> = ({ table }) => {
     selectedIds, editingTableId, editingColumnId,
     setSelectedIds, toggleSelected, setEditingTableId, setEditingColumnId,
     updateTableName, moveTable, addColumn, updateColumn, removeColumn, removeTable,
-    duplicateTable, connectingFrom, setConnectingFrom, addRelationship, groups, moveTableToGroup, tables,
+    duplicateTable, connectingFrom, setConnectingFrom, addRelationship, groups, moveTableToGroup, tables, saveHistory,
   } = useSchemaStore();
 
   const isSelected = selectedIds.includes(table.id);
@@ -91,13 +91,14 @@ export const TableBlock: React.FC<TableBlockProps> = ({ table }) => {
       const isHandle = !!el.closest('.table-drag-handle');
       if (!isHandle) return;
 
+      saveHistory();
       setDragging(true);
       setDragOffset({
         x: e.clientX / useSchemaStore.getState().zoom - table.position.x,
         y: e.clientY / useSchemaStore.getState().zoom - table.position.y,
       });
     },
-    [table.id, table.position, isSelected, setSelectedIds, toggleSelected]
+    [table.id, table.position, isSelected, setSelectedIds, toggleSelected, saveHistory]
   );
 
   useEffect(() => {
@@ -238,6 +239,7 @@ export const TableBlock: React.FC<TableBlockProps> = ({ table }) => {
                       ref={nameInputRef}
                       className={`bg-transparent text-[15px] font-semibold outline-none w-full ${isDuplicateTableName ? 'text-destructive' : 'text-foreground'}`}
                       value={table.name}
+                      onFocus={() => saveHistory()}
                       onChange={(e) => updateTableName(table.id, e.target.value)}
                       onKeyDown={(e) => handleKeyDown(e)}
                       onBlur={() => setEditingTableId(null)}
@@ -408,7 +410,7 @@ interface ColumnRowProps {
 const ColumnRow: React.FC<ColumnRowProps> = ({
   column, tableId, columns, isEditing, isConnecting, onConnect, onKeyDown,
 }) => {
-  const { setEditingColumnId, updateColumn, removeColumn } = useSchemaStore();
+  const { setEditingColumnId, updateColumn, removeColumn, saveHistory } = useSchemaStore();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const isDuplicateColumnName = columns.some(c => c.id !== column.id && c.name.toLowerCase() === column.name.toLowerCase());
@@ -454,6 +456,7 @@ const ColumnRow: React.FC<ColumnRowProps> = ({
               }`}
               onClick={(e) => {
                 e.stopPropagation();
+                saveHistory();
                 const nextPrimary = !column.isPrimaryKey;
                 updateColumn(tableId, column.id, {
                   isPrimaryKey: nextPrimary,
@@ -481,6 +484,7 @@ const ColumnRow: React.FC<ColumnRowProps> = ({
                 ref={inputRef}
                 className={`bg-transparent text-[13px] font-medium outline-none flex-1 min-w-0 ${isDuplicateColumnName ? 'text-destructive' : 'text-foreground'}`}
                 value={column.name}
+                onFocus={() => saveHistory()}
                 onChange={(e) => updateColumn(tableId, column.id, { name: e.target.value })}
                 onKeyDown={onKeyDown}
                 onBlur={() => setEditingColumnId(null)}
@@ -516,7 +520,10 @@ const ColumnRow: React.FC<ColumnRowProps> = ({
       <div className="flex items-center gap-1 pl-2 pr-0.5 flex-shrink-0">
         <DataTypePicker
           value={column.type}
-          onSelect={(type) => updateColumn(tableId, column.id, { type })}
+          onSelect={(type) => {
+            saveHistory();
+            updateColumn(tableId, column.id, { type });
+          }}
         />
 
         <Tooltip>
@@ -530,6 +537,7 @@ const ColumnRow: React.FC<ColumnRowProps> = ({
               onClick={(e) => {
                 e.stopPropagation();
                 if (column.isPrimaryKey) return;
+                saveHistory();
                 updateColumn(tableId, column.id, { isNullable: !column.isNullable });
               }}
             >

--- a/src/components/canvas/WelcomeOverlay.tsx
+++ b/src/components/canvas/WelcomeOverlay.tsx
@@ -179,12 +179,12 @@ export const WelcomeOverlay: React.FC = () => {
     },
     {
       id: 'ai-chat',
-      label: 'Zoom controls\n& shortcuts',
-      fromAbs: { x: 178, y: h - 86 },
-      toAbs: { x: 136, y: h - 58 },
+      label: 'Zoom controls\n& history',
+      fromAbs: { x: 263, y: h - 86 },
+      toAbs: { x: 221, y: h - 58 },
       curvature: -0.14,
       delay: 0.55,
-      labelStyle: { bottom: 92, left: 176, textAlign: 'left' } as React.CSSProperties,
+      labelStyle: { bottom: 92, left: 261, textAlign: 'left' } as React.CSSProperties,
     },
     {
       id: 'zoom-help',
@@ -286,7 +286,7 @@ export const WelcomeOverlay: React.FC = () => {
           <div
             className="absolute pointer-events-none"
             style={{
-              top: '44%',
+              top: '48%',
               left: '50%',
               transform: 'translate(-50%, -50%)',
               width: '100%',
@@ -321,7 +321,7 @@ export const WelcomeOverlay: React.FC = () => {
               </motion.div>
 
               <motion.p
-                className="text-base text-muted-foreground flex justify-center w-full leading-relaxed mb-5 leading-tight"
+                className="text-base text-muted-foreground flex justify-center w-full leading-normal mb-5"
                 style={{ fontFamily: '"ManropeLocal", "Manrope", ui-sans-serif, system-ui, sans-serif' }}
                 initial={{ y: 15, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,15 +15,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[100] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/src/store/schemaStore.ts
+++ b/src/store/schemaStore.ts
@@ -212,6 +212,18 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
   saveHistory: () => {
     const s = get();
     set((state) => {
+      // Don't save if current state is exactly the same as the top of the past stack
+      if (state.past.length > 0) {
+        const last = state.past[state.past.length - 1];
+        if (
+          last.tables === state.tables &&
+          last.groups === state.groups &&
+          last.relationships === state.relationships
+        ) {
+          return state;
+        }
+      }
+      
       const snapshot = { tables: state.tables, groups: state.groups, relationships: state.relationships };
       const newPast = [...state.past, snapshot];
       if (newPast.length > 50) newPast.shift();
@@ -221,9 +233,21 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
 
   undo: () => {
     set((s) => {
-      if (s.past.length === 0) return s;
-      const prev = s.past[s.past.length - 1];
-      const newPast = s.past.slice(0, -1);
+      let newPast = [...s.past];
+      let prev: Pick<SchemaStore, 'tables' | 'groups' | 'relationships'> | undefined;
+
+      // Keep popping until we find a distinctly different state to restore
+      while (newPast.length > 0) {
+        prev = newPast[newPast.length - 1];
+        newPast = newPast.slice(0, -1);
+        if (prev.tables !== s.tables || prev.groups !== s.groups || prev.relationships !== s.relationships) {
+          break;
+        }
+        prev = undefined;
+      }
+
+      if (!prev) return s;
+
       return {
         past: newPast,
         future: [{ tables: s.tables, groups: s.groups, relationships: s.relationships }, ...s.future],
@@ -237,9 +261,21 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
 
   redo: () => {
     set((s) => {
-      if (s.future.length === 0) return s;
-      const next = s.future[0];
-      const newFuture = s.future.slice(1);
+      let newFuture = [...s.future];
+      let next: Pick<SchemaStore, 'tables' | 'groups' | 'relationships'> | undefined;
+
+      // Keep popping forward until we find a distinctly different state to restore
+      while (newFuture.length > 0) {
+        next = newFuture[0];
+        newFuture = newFuture.slice(1);
+        if (next.tables !== s.tables || next.groups !== s.groups || next.relationships !== s.relationships) {
+          break;
+        }
+        next = undefined;
+      }
+
+      if (!next) return s;
+
       return {
         past: [...s.past, { tables: s.tables, groups: s.groups, relationships: s.relationships }],
         future: newFuture,

--- a/src/store/schemaStore.ts
+++ b/src/store/schemaStore.ts
@@ -18,6 +18,18 @@ export function getTableHeight(table: TableNode): number {
   return TABLE_HEADER_HEIGHT + table.columns.length * COLUMN_ROW_HEIGHT + 32;
 }
 
+export function getTableWidth(table: TableNode): number {
+  if (!table) return DEFAULT_TABLE_WIDTH;
+  const longestColumnNameLength = table.columns.reduce(
+    (max, col) => Math.max(max, col.name.length),
+    0
+  );
+  const estimatedNameWidth = Math.max(140, longestColumnNameLength * 8 + 26);
+  const fixedControlsWidth = 188;
+  const dynamicWidth = estimatedNameWidth + fixedControlsWidth;
+  return Math.max(DEFAULT_TABLE_WIDTH, table.width || DEFAULT_TABLE_WIDTH, dynamicWidth);
+}
+
 function getTablesForGroup(tables: TableNode[], groupId: string): TableNode[] {
   return tables.filter(t => t.groupId === groupId);
 }
@@ -30,7 +42,7 @@ function computeGroupBounds(tables: TableNode[], group: GroupNode): { x: number;
 
   const minX = Math.min(...groupTables.map(t => t.position.x));
   const minY = Math.min(...groupTables.map(t => t.position.y));
-  const maxX = Math.max(...groupTables.map(t => t.position.x + (t.width || DEFAULT_TABLE_WIDTH)));
+  const maxX = Math.max(...groupTables.map(t => t.position.x + getTableWidth(t)));
   const maxY = Math.max(...groupTables.map(t => t.position.y + getTableHeight(t)));
 
   return {
@@ -71,9 +83,17 @@ interface SchemaStore {
   editingColumnId: string | null;
   connectingFrom: { tableId: string; columnId: string } | null;
 
+  // History State
+  past: Pick<SchemaStore, 'tables' | 'groups' | 'relationships'>[];
+  future: Pick<SchemaStore, 'tables' | 'groups' | 'relationships'>[];
+
   // Actions
+  saveHistory: () => void;
+  undo: () => void;
+  redo: () => void;
   addTable: (position: { x: number; y: number }) => string;
   removeTable: (id: string) => void;
+  removeTables: (ids: string[]) => void;
   updateTableName: (id: string, name: string) => void;
   moveTable: (id: string, position: { x: number; y: number }) => void;
   duplicateTable: (id: string) => void;
@@ -186,7 +206,53 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
   editingColumnId: null,
   connectingFrom: null,
 
+  past: [],
+  future: [],
+
+  saveHistory: () => {
+    const s = get();
+    set((state) => {
+      const snapshot = { tables: state.tables, groups: state.groups, relationships: state.relationships };
+      const newPast = [...state.past, snapshot];
+      if (newPast.length > 50) newPast.shift();
+      return { past: newPast, future: [] };
+    });
+  },
+
+  undo: () => {
+    set((s) => {
+      if (s.past.length === 0) return s;
+      const prev = s.past[s.past.length - 1];
+      const newPast = s.past.slice(0, -1);
+      return {
+        past: newPast,
+        future: [{ tables: s.tables, groups: s.groups, relationships: s.relationships }, ...s.future],
+        tables: prev.tables,
+        groups: prev.groups,
+        relationships: prev.relationships,
+        selectedIds: [],
+      };
+    });
+  },
+
+  redo: () => {
+    set((s) => {
+      if (s.future.length === 0) return s;
+      const next = s.future[0];
+      const newFuture = s.future.slice(1);
+      return {
+        past: [...s.past, { tables: s.tables, groups: s.groups, relationships: s.relationships }],
+        future: newFuture,
+        tables: next.tables,
+        groups: next.groups,
+        relationships: next.relationships,
+        selectedIds: [],
+      };
+    });
+  },
+
   addTable: (position) => {
+    get().saveHistory();
     const id = uid();
     const colId = uid();
     
@@ -220,14 +286,29 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
     return id;
   },
 
-  removeTable: (id) =>
+  removeTable: (id) => {
+    get().saveHistory();
     set((s) => ({
       tables: s.tables.filter((t) => t.id !== id),
       relationships: s.relationships.filter(
         (r) => r.sourceTableId !== id && r.targetTableId !== id
       ),
       selectedIds: s.selectedIds.filter((sid) => sid !== id),
-    })),
+    }));
+  },
+
+  removeTables: (ids) => {
+    if (ids.length === 0) return;
+    get().saveHistory();
+    const idSet = new Set(ids);
+    set((s) => ({
+      tables: s.tables.filter((t) => !idSet.has(t.id)),
+      relationships: s.relationships.filter(
+        (r) => !idSet.has(r.sourceTableId) && !idSet.has(r.targetTableId)
+      ),
+      selectedIds: s.selectedIds.filter((sid) => !idSet.has(sid)),
+    }));
+  },
 
   updateTableName: (id, name) =>
     set((s) => ({
@@ -240,6 +321,7 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
     })),
 
   duplicateTable: (id) => {
+    get().saveHistory();
     const table = get().tables.find((t) => t.id === id);
     if (!table) return;
     const newId = uid();
@@ -254,7 +336,8 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
     set((s) => ({ tables: [...s.tables, newTable] }));
   },
 
-  moveTableToGroup: (tableId, groupId) =>
+  moveTableToGroup: (tableId, groupId) => {
+    get().saveHistory();
     set((s) => {
       const table = s.tables.find((t) => t.id === tableId);
       if (!table) return s;
@@ -288,9 +371,11 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
           t.id === tableId ? { ...t, groupId, position: nextPos } : t
         ),
       };
-    }),
+    });
+  },
 
   addGroup: (position) => {
+    get().saveHistory();
     const id = uid();
     const group: GroupNode = {
       id,
@@ -305,6 +390,7 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
   },
 
   addTableToGroup: (groupId) => {
+    get().saveHistory();
     const state = get();
     const group = state.groups.find((g) => g.id === groupId);
     if (!group) return null;
@@ -362,13 +448,16 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
     return id;
   },
 
-  removeGroup: (id) =>
+  removeGroup: (id) => {
+    get().saveHistory();
     set((s) => ({
       groups: s.groups.filter((g) => g.id !== id),
       tables: s.tables.map((t) => (t.groupId === id ? { ...t, groupId: undefined } : t)),
-    })),
+    }));
+  },
 
-  removeGroupAndTables: (id) =>
+  removeGroupAndTables: (id) => {
+    get().saveHistory();
     set((s) => {
       const tableIdsToRemove = new Set(s.tables.filter(t => t.groupId === id).map(t => t.id));
 
@@ -379,17 +468,20 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
           (r) => !tableIdsToRemove.has(r.sourceTableId) && !tableIdsToRemove.has(r.targetTableId)
         ),
       };
-    }),
+    });
+  },
 
   updateGroupName: (id, name) =>
     set((s) => ({
       groups: s.groups.map((g) => (g.id === id ? { ...g, name } : g)),
     })),
 
-  updateGroupColor: (id, color) =>
+  updateGroupColor: (id, color) => {
+    get().saveHistory();
     set((s) => ({
       groups: s.groups.map((g) => (g.id === id ? { ...g, color } : g)),
-    })),
+    }));
+  },
 
   moveGroup: (id, position, delta) =>
     set((s) => {
@@ -419,7 +511,7 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
       if (tablesInside.length > 0) {
         const minTableX = Math.min(...tablesInside.map((t) => t.position.x));
         const minTableY = Math.min(...tablesInside.map((t) => t.position.y));
-        const maxTableX = Math.max(...tablesInside.map((t) => t.position.x + t.width));
+        const maxTableX = Math.max(...tablesInside.map((t) => t.position.x + getTableWidth(t)));
         const maxTableY = Math.max(...tablesInside.map((t) => t.position.y + getTableHeight(t)));
 
         const mustLeft = minTableX - GROUP_PAD_LEFT;
@@ -444,6 +536,7 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
     }),
 
   addColumn: (tableId) => {
+    get().saveHistory();
     const colId = uid();
     
     // Generate a unique column name
@@ -490,7 +583,8 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
       ),
     })),
 
-  removeColumn: (tableId, columnId) =>
+  removeColumn: (tableId, columnId) => {
+    get().saveHistory();
     set((s) => ({
       tables: s.tables.map((t) =>
         t.id === tableId
@@ -502,24 +596,30 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
           !(r.sourceTableId === tableId && r.sourceColumnId === columnId) &&
           !(r.targetTableId === tableId && r.targetColumnId === columnId)
       ),
-    })),
+    }));
+  },
 
   addRelationship: (rel) => {
+    get().saveHistory();
     const id = uid();
     set((s) => ({ relationships: [...s.relationships, { ...rel, id }] }));
   },
 
-  removeRelationship: (id) =>
+  removeRelationship: (id) => {
+    get().saveHistory();
     set((s) => ({
       relationships: s.relationships.filter((r) => r.id !== id),
-    })),
+    }));
+  },
 
-  updateRelationshipCardinality: (id, cardinality) =>
+  updateRelationshipCardinality: (id, cardinality) => {
+    get().saveHistory();
     set((s) => ({
       relationships: s.relationships.map((r) =>
         r.id === id ? { ...r, cardinality } : r
       ),
-    })),
+    }));
+  },
 
   setPan: (pan) => set({ pan }),
   setZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
@@ -535,7 +635,8 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
   setEditingColumnId: (id) => set({ editingColumnId: id }),
   setConnectingFrom: (from) => set({ connectingFrom: from }),
 
-  clearAll: () =>
+  clearAll: () => {
+    get().saveHistory();
     set({
       tables: [],
       groups: [],
@@ -543,9 +644,11 @@ export const useSchemaStore = create<SchemaStore>((set, get) => ({
       selectedIds: [],
       editingTableId: null,
       editingColumnId: null,
-    }),
+    });
+  },
 
   importSchema: (sql) => {
+    get().saveHistory();
     import('@/utils/sqlParser').then(({ parseSql }) => {
       const { tables: parsedTables, relationships: parsedRelationships } = parseSql(sql);
       set((state) => {


### PR DESCRIPTION
### undo/redo (main changes related to the PR)
- Add history (past/future) using `saveHistory`
- Implement `undo` / `redo` in schema store
- Track all major actions (add, delete, move, resize, etc.)
- Add UI buttons + tooltips (near zoom controls)
- Add shortcuts: `Ctrl/Cmd + Z`, `Shift + Ctrl/Cmd + Z`

### Small fixes and other changes
- Use Popover for context menu (handles outside click)
- Fix tooltip layering with Portal + z-index
- Dynamic table width (`getTableWidth`) for layout
- Batch delete API (`removeTables`)
- Minor UI fixes (WelcomeOverlay)